### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 vendor
 mix-manifest.json
+.DS_Store


### PR DESCRIPTION
Simply ignores .DS_Store files, avoids Mac users accidentally commiting these files.